### PR TITLE
Only unregister the listener when eph is true

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -289,7 +289,9 @@ impl AsyncTcpStream {
 
 impl Drop for AsyncTcpStream {
     fn drop(&mut self) {
-        self.epoll.ctl_del_rawfd(self.stream.as_raw_fd()).unwrap();
+        if self.eph {
+            self.epoll.ctl_del_rawfd(self.stream.as_raw_fd()).unwrap();
+        }
     }
 }
 


### PR DESCRIPTION
Thank you for this repo, it helped me a lot to grasp the basics of asynchronous servers under linux ! 

Nevertheless -on my config- after any request, the current version of this repo will panic at the end of the connection, when dropping the  `AsyncTcpStream`, with this error:
`epoll:ctl_del_rawfd:error: No such file or directory`

My guess is, when a tcp stream is dropped, it's already been automatically unregistered from its `Epoll` file descriptor set, because of the use of the flag **EPOLLONESHOT**

A quick way to solve this is to check if the stream still belong to an Epoll file descriptor set, by looking at `stream.eph` flag.